### PR TITLE
Add the atlas folder to LD_LIBRARY_PATH

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -59,7 +59,7 @@ export PATH=$BUILD_DIR/.heroku/python/bin:$PATH
 export PYTHONUNBUFFERED=1
 export LANG=en_US.UTF-8
 export LIBRARY_PATH=/app/.heroku/vendor/lib
-export LD_LIBRARY_PATH=/app/.heroku/vendor/lib
+export LD_LIBRARY_PATH=$LIBRARY_PATH
 
 # Switch to the repo's context.
 cd $BUILD_DIR
@@ -181,8 +181,8 @@ source $BIN_DIR/steps/collectstatic
 set-env PATH '$HOME/.heroku/python/bin:$PATH'
 set-env PYTHONUNBUFFERED true
 set-env PYTHONHOME /app/.heroku/python
-set-default-env LIBRARY_PATH /app/.heroku/vendor/lib
-set-default-env LD_LIBRARY_PATH /app/.heroku/vendor/lib
+set-default-env LIBRARY_PATH $LIBRARY_PATH
+set-default-env LD_LIBRARY_PATH $LD_LIBRARY_PATH
 set-default-env LANG en_US.UTF-8
 set-default-env PYTHONHASHSEED random
 set-default-env PYTHONPATH /app/


### PR DESCRIPTION
To make the build pack work and able to unpickle sklearn models built offline I add to:

```
$ heroku config:set BUILDPACK_URL=https://github.com/dbrgn/heroku-buildpack-python-sklearn/
$ heroku config:add LD_LIBRARY_PATH=/app/.heroku/vendor/lib/atlas-base/atlas:/app/.heroku/vendor/lib/atlas-base:/app/.heroku/vendor/lib/
```

otherwise I get a:

```
ImportError: liblapack.so.3gf: cannot open shared object file: No such file or directory
```

when the application loads scipy.

Presumably setting `LD_LIBRARY_PATH` directly in the build back will remove that manual configuration step.
